### PR TITLE
 consultationテーブルにuuid_urlを追加

### DIFF
--- a/db/migrate/20251010034008_enable_pgcrypto_extension.rb
+++ b/db/migrate/20251010034008_enable_pgcrypto_extension.rb
@@ -1,0 +1,6 @@
+class EnablePgcryptoExtension < ActiveRecord::Migration[7.2]
+  def change
+    # PostgreSQLに対して、UUID生成関数(gen_random_uuid)を使えるように指示
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20251010034524_add_uuid_url_to_consultations.rb
+++ b/db/migrate/20251010034524_add_uuid_url_to_consultations.rb
@@ -1,0 +1,9 @@
+class AddUuidUrlToConsultations < ActiveRecord::Migration[7.2]
+  def change
+    # 'uuid_url'というカラムをUUID型で追加。
+    # 最初は既存のレコードのために null: true (空を許容) に設定します。
+    # unique: true で重複しないことを保証します。
+    add_column :consultations, :uuid_url, :uuid, null: true
+    add_index :consultations, :uuid_url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_02_111047) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_10_034524) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "answers", force: :cascade do |t|
@@ -38,7 +39,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_02_111047) do
     t.string "status", default: "draft", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "uuid_url"
     t.index ["user_id"], name: "index_consultations_on_user_id"
+    t.index ["uuid_url"], name: "index_consultations_on_uuid_url", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/uuid.rake
+++ b/lib/tasks/uuid.rake
@@ -1,0 +1,25 @@
+namespace :uuid do
+    # taskの説明
+    desc "既存のConsultationレコードにUUIDを割り当てる"
+    # task_nameはassign_url_uuids、環境変数を読み込むために:environmentを指定
+    task assign_url_uuids: :environment do
+      puts "UUIDの一括割り当てを開始します"
+
+      # 1. uuid_urlがNULLのレコードをすべて取得
+      consultations_to_update = Consultation.where(uuid_url: nil)
+
+      # 2. 処理数を表示
+      puts "対象レコード数: #{consultations_to_update.count}"
+
+      # 3. 取得したレコードを一つずつ更新
+      consultations_to_update.find_each do |consultation|
+        # gen_random_uuid() をデータベースに直接実行させ、UUIDを効率的に生成・保存
+        # update_columnsを使うと、バリデーション（検証）やコールバック（フック）をスキップして高速に更新できるrailsのメソッド
+        # Consultation.connection.select_value("SELECT gen_random_uuid()") は、PostgreSQLのgen_random_uuid()関数を直接呼び出して新しいUUIDを生成し、その値を取得する
+        consultation.update_columns(uuid_url: Consultation.connection.select_value("SELECT gen_random_uuid()"))
+        print "." # 進行状況を示すドットを表示
+      end
+      # \nは改行の意味
+      puts "\nUUIDの一括割り当てが完了しました。"
+    end
+  end


### PR DESCRIPTION
-  consultationテーブルにuuid_urlを追加 (本番環境でrakeタスクで既存のconsultationテーブルのデータにもuuid_urlを追加するためNULLを許可)