### PR TITLE
salons/consultations_controllerの作成

### DIFF
--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -20,7 +20,12 @@ class ConsultationsController < ApplicationController
     # 4. カルテに紐づく回答を取得
     @answers = @consultation.answers.order(created_at: :asc)
 
-    # 5. 通常のカルテ詳細ビューを再利用して表示
+    # 5. ログインしているサロンがいる場合、初回アクセス時のみ紐づける
+    if current_salon && @consultation.salon_id.nil?
+      @consultation.update!(salon_id: current_salon.id)
+    end
+
+    # 6. 通常のカルテ詳細ビューを再利用して表示
     render "consultations/show"
   end
 

--- a/app/controllers/salons/consultations_controller.rb
+++ b/app/controllers/salons/consultations_controller.rb
@@ -8,6 +8,8 @@ module Salons
       layout "salon_application"
       # GET /salons/consultations (美容師モードのホーム/カルテ一覧)
       def index
+        # ログイン中の美容師に紐づくConsultationを全て取得し、作成日時の降順で並べる
+        @consultations = current_salon.consultations.order(created_at: :desc)
       end
 
       def scan

--- a/app/views/salons/shared/_header.html.erb
+++ b/app/views/salons/shared/_header.html.erb
@@ -17,7 +17,7 @@
         <ul class="absolute top-full right-0 mt-3 w-52 p-2 shadow-xl bg-gray-800/90 backdrop-blur-sm rounded-lg z-10 text-white space-y-1">
           <!-- サロン側 -->
             <li><a href="#" class="block px-4 py-2 hover:bg-gray-700/80 rounded-md">マイページ</a></li>
-            <li><a href="#" class="block px-4 py-2 hover:bg-gray-700/80 rounded-md">QRコード読み取り</a></li>
+            <li><%= link_to "QRコード読み取り", scan_salons_consultations_path, class: "block px-4 py-2 hover:bg-gray-700/80 rounded-md" %></li>
             <li><a href="#" class="block px-4 py-2 hover:bg-gray-700/80 rounded-md">使い方ガイド</a></li>
             <li><a href="#" class="block px-4 py-2 hover:bg-gray-700/80 rounded-md">プライバシーポリシー</a></li>
             <li><a href="#" class="block px-4 py-2 hover:bg-gray-700/80 rounded-md">利用規約</a></li>


### PR DESCRIPTION
- app/controllers/consultations_controller.rbのQRで確認できるものにログイン済みのサロン側が見た時、consultationテーブルにsalon_idが紐ずくように編集
- ヘッダーのQR読み取りにルートを追加
- app/controllers/salons/consultations_controller.rbのindexにsalon_idが紐付いているconsultation一覧を表示するよう記述