### PR TITLE
LINEログイン後のリダイレクトページの変更

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -27,7 +27,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # ログイン後のflash messageとリダイレクト先を設定
       flash[:notice] = "ログインしました"
       # ここのリダイレクト先は後で自分のルーティングに応じて変更する
-      redirect_to expendable_items_path
+      redirect_to root_path
     end
 
     # ダミーのemailアドレスを作成するメソッド


### PR DESCRIPTION
- 本番環境でメールが送れない、LINEログインできないのはrenderに変数を設定していないことがわかったため、renderに変数を入れる
- LINEログイン後のリダイレクトページの変更