### PR TITLE
新規登録の性別、年代のviewの変更

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,12 +23,12 @@
           <!-- 性別 -->
           <div class="mb-4">
             <label class="block text-gray-700 font-medium mb-1"><%=t('.gender') %></label>
-            <%= f.text_field :gender, class: "w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder: t('.gender') %>
+            <%= f.select :gender, [['男性', '男性'], ['女性', '女性'], ['その他', 'その他']], { include_blank: "選択してください" }, { class: "w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"} %>
           </div>
           <!-- 年齢 -->
           <div class="mb-4">
             <label class="block text-gray-700 font-medium mb-1">年齢</label>
-            <%= f.text_field :age_group, class: "w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder: t('.age_group') %>
+            <%= f.select :age_group, [['10歳未満', '0'], ['10代', '10'], ['20代', '20'], ['30代', '30'], ['40代', '40'], ['50代以上', '50']], { include_blank: "選択してください" }, { class: "w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"} %>
           </div>
           <!-- パスワード -->
           <div class="mb-4">


### PR DESCRIPTION
- ユーザー側の新規登録画面の「性別」、「年齢」の部分をセレクト形式で選ぶ様に変更する
作業手順
- app/views/devise/registrations/new.html.erbのフォーム部分の性別をf.text_field からf.select に変更し、「男性」、「女性」、「その他」の３つから選べる様にする
- app/views/devise/registrations/new.html.erbのフォーム部分の性別をf.text_field からf.select に変更し、選択式に変更